### PR TITLE
fix build for non-linux targets

### DIFF
--- a/arp-scan-lib/src/utils.rs
+++ b/arp-scan-lib/src/utils.rs
@@ -2,7 +2,6 @@ use std::process;
 use std::sync::Arc;
 
 use crate::scan_options::ScanOptions;
-#[cfg(target_os = "linux")]
 use ipnetwork::{IpNetwork, NetworkSize};
 use pnet_datalink::NetworkInterface;
 

--- a/arp-scan/Cargo.toml
+++ b/arp-scan/Cargo.toml
@@ -22,9 +22,6 @@ clap = { workspace = true, default-features = false, features = ["std", "suggest
 ansi_term = { workspace = true }
 ctrlc = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-caps = { workspace = true }
-
 # Network
 pnet = { workspace = true }
 pnet_datalink = { workspace = true }
@@ -36,3 +33,6 @@ csv = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = { workspace = true }

--- a/arp-scan/src/cli_utils.rs
+++ b/arp-scan/src/cli_utils.rs
@@ -2,6 +2,7 @@ use ansi_term::Color::{Green, Red};
 use arp_scan_lib::network::{ResponseSummary, TargetDetails};
 use arp_scan_lib::scan_options::ScanOptions;
 use arp_scan_lib::utils::select_default_interface;
+#[cfg(target_os = "linux")]
 use caps::{CapSet, Capability, has_cap};
 use pnet_datalink::NetworkInterface;
 use serde::Serialize;


### PR DESCRIPTION
Fixes https://github.com/kongbytes/arp-scan-rs/issues/9

Removes pnet target-specific dependency and gates caps import for linux only.